### PR TITLE
fix(README.md,Makefile) updates outdated instructions for compiling t…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-MKLEANBOOK_PATH := $(PWD)/mkleanbook
+MKLEANBOOK_PATH := ../mkleanbook
 
 AUTHORS = Jeremy Avigad, Leonardo de Moura, Gabriel Ebner, and Sebastian Ullrich
 TITLE = An Introduction to Lean

--- a/README.md
+++ b/README.md
@@ -14,10 +14,14 @@ We use [cask][cask] to install emacs dependencies ([org-mode][org-mode], [lean-m
 sudo apt-get install mercurial python2.7 texlive-latex-recommended \
                      texlive-humanities texlive-xetex texlive-science \
                      texlive-latex-extra texlive-fonts-recommended texlive-luatex\
-                     bibtex2html git make mercurial autoconf automake gcc curl
+                     bibtex2html git make mercurial autoconf automake gcc curl \
+					 latexmk
 git clone https://github.com/leanprover/introduction_to_lean
+git clone https://github.com/leanprover/mkleanbook.git
+
 cd introduction_to_lean
 make install-cask # after this, you need to add the cask binary to your $PATH
+export PATH="$HOME/.cask/bin:$PATH"
 make install-pygments
 make
 ```


### PR DESCRIPTION
…he tutorial

1. include dependency on `latexmk`
2. include step for cloning the `mkleanbook` repo
3. modify path in `Makefile` so it points to `mkleanbook`
4. include step for adding `$HOME/.cask` directory to `$PATH`

Tutorial now compiles correctly on (mostly) stock Ubuntu 17.10.